### PR TITLE
Implemented `Impurity` module using massiv. Along with some benchmarks:

### DIFF
--- a/bench/BenchImpurity.hs
+++ b/bench/BenchImpurity.hs
@@ -37,7 +37,11 @@ mkImpurityBenchmarks k =
     [ env (return (computeAs P $ makeRandomArray k)) $ \arr ->
         bgroup
           "Massiv"
-          [bench "Tally" $ nf (computeAs U . A.tally) arr]
+          [ bench "Tally" $ nf (computeAs U . A.tally) arr
+          , bench "Entropy" $ whnf A.entropy arr
+          ]
     , env (return (A.toList $ computeAs P $ makeRandomArray k)) $ \xs ->
-        bgroup "List+Map" [bench "Tally" $ nf L.tally xs]
+        bgroup
+          "List+Map"
+          [bench "Tally" $ nf L.tally xs, bench "Entropy" $ whnf L.entropy xs]
     ]

--- a/bench/BenchImpurity.hs
+++ b/bench/BenchImpurity.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeApplications #-}
+module Main where
+
+import Control.Monad (unless)
+import Data.Massiv.Array as A
+import Criterion.Main
+import System.Random
+import Impurity as L
+import ImpurityMassiv as A
+import Data.List as List (sort)
+
+main :: IO ()
+main = do
+  let massiv = A.toList $ computeAs U $ A.tally $ computeAs P $ makeRandomArray 20
+      mapList = L.tallyM $ A.toList $ computeAs P $ makeRandomArray 20
+  -- Sanity check:
+  unless (List.sort massiv == List.sort mapList) $ error "Results do not match"
+  defaultMain
+    [ mkImpurityBenchmarks 20
+    , mkImpurityBenchmarks 2000
+    , mkImpurityBenchmarks 200000
+    ]
+
+makeRandomArray :: Int -> Array DL Ix1 Int
+makeRandomArray maxVal =
+  let n = Sz1 160000
+      gen = mkStdGen 2019
+   in randomArray gen split (randomR (0, maxVal)) Par n
+
+
+
+mkImpurityBenchmarks :: Int -> Benchmark
+mkImpurityBenchmarks k =
+  bgroup
+    ("Impurity " ++ show k)
+    [ env (return (computeAs P $ makeRandomArray k)) $ \arr ->
+        bgroup
+          "Massiv"
+          [bench "Tally" $ nf (computeAs U . A.tally) arr]
+    , env (return (A.toList $ computeAs P $ makeRandomArray k)) $ \xs ->
+        bgroup "List+Map" [bench "Tally" $ nf L.tally xs]
+    ]

--- a/gump.cabal
+++ b/gump.cabal
@@ -15,9 +15,10 @@ extra-source-files:  Readme.md, Spec.md
 library
   exposed-modules:
       ID3
+    , Impurity
+    , ImpurityMassiv
   other-modules:
-      Impurity
-    , TestData
+      TestData
     , ID3Simple
     , ID3Massiv
     , Feature
@@ -44,3 +45,15 @@ library
     -Wall -Wcompat -Wincomplete-record-updates
     -Wincomplete-uni-patterns -Wredundant-constraints
   default-language: Haskell2010
+
+benchmark impurity
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  main-is:             BenchImpurity.hs
+  ghc-options:         -Wall -threaded -O2 -rtsopts -with-rtsopts=-N
+  build-depends:       base
+                     , criterion
+                     , gump
+                     , massiv
+                     , random
+  default-language:    Haskell2010

--- a/src/Impurity.hs
+++ b/src/Impurity.hs
@@ -29,6 +29,7 @@ proportions xs =
     where
         counts = M.elems (tally xs)
         n = fromIntegral $ length xs
+{-# INLINE proportions #-}
 
 
 -- entropy measure
@@ -36,6 +37,7 @@ proportions xs =
 entropy :: (Foldable t, Ord a) => t a -> Double
 entropy xs =
     -Prelude.sum [p * logBase 2 p | p <- proportions xs]
+{-# INLINE entropy #-}
 
 
 -- gini coefficient as an impurity measure

--- a/src/Impurity.hs
+++ b/src/Impurity.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Impurity where
@@ -6,14 +8,18 @@ import           Data.Foldable as F
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 
-
 -- count the number of occurrences of every list element
 tally :: forall t a . (Foldable t, Ord a) => t a -> Map a Int
 tally elements =
     F.foldr' addCount M.empty elements
     where
         addCount :: a -> Map a Int -> Map a Int
-        addCount el counter = M.insertWith (+) el 1 counter
+        addCount !el !counter = M.insertWith (+) el 1 counter
+        {-# INLINE addCount #-}
+{-# INLINE tally #-}
+
+tallyM :: forall t a . (Foldable t, Ord a) => t a -> [(a, Int)]
+tallyM = M.toList . tally
 
 
 -- calculate which element occurs which percentage of the time
@@ -29,16 +35,16 @@ proportions xs =
 -- https://en.wikipedia.org/wiki/Entropy#Statistical_mechanics
 entropy :: (Foldable t, Ord a) => t a -> Double
 entropy xs =
-    -sum [p * logBase 2 p | p <- proportions xs]
+    -Prelude.sum [p * logBase 2 p | p <- proportions xs]
 
 
 -- gini coefficient as an impurity measure
 gini :: (Foldable t, Ord a) => t a -> Double
 gini xs =
-    sum [p * (1 - p) | p <- proportions xs]
+    Prelude.sum [p * (1 - p) | p <- proportions xs]
 
 
 -- misclassification coefficient as an impurity measure
 misclassification :: (Foldable t, Ord a) => t a -> Double
 misclassification xs =
-    1 - maximum (proportions xs)
+    1 - Prelude.maximum (proportions xs)

--- a/src/ImpurityMassiv.hs
+++ b/src/ImpurityMassiv.hs
@@ -1,0 +1,61 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module ImpurityMassiv where
+
+import Data.Massiv.Array as A
+import Data.Massiv.Array.Unsafe as A
+
+tally ::
+     (Mutable r Ix1 e, Resize r ix, Ord e, Load r ix e)
+  => Array r ix e
+  -> Array DS Ix1 (e, Int)
+tally arr
+  | isEmpty arr = A.empty
+  | otherwise = A.mapMaybeS id $ A.unfoldrN (sz + 1) count (0, 0, sorted ! 0)
+  where
+    sz@(Sz k) = size sorted
+    count (!i, !n, !prev)
+      | i < k =
+        let !e' = A.unsafeLinearIndex sorted i
+         in if prev == e'
+              then Just (Nothing, (i + 1, n + 1, prev))
+              else Just (Just (prev, n), (i + 1, 1, e'))
+      | otherwise = Just (Just (prev, n), (i + 1, n, prev))
+    {-# INLINE count #-}
+    sorted = A.quicksort $ flatten arr
+{-# INLINE tally #-}
+
+proportions ::
+     (Mutable r Ix1 a, Resize r ix, Ord a, Load r ix a)
+  => Array r ix a
+  -> Array D Ix1 Double
+proportions arr = A.map (\c -> fromIntegral c / n) counts
+  where
+    counts = computeAs P (snd <$> tally arr)
+    n = fromIntegral $ unSz $ size counts
+
+
+entropy ::
+     (Mutable r Ix1 a, Resize r ix, Ord a, Load r ix a)
+  => Array r ix a
+  -> Double
+entropy = negate . A.sum . A.map (\p -> p * logBase 2 p) . proportions
+
+
+
+gini ::
+     (Mutable r Ix1 a, Resize r ix, Ord a, Load r ix a)
+  => Array r ix a
+  -> Double
+gini = A.sum . A.map (\p -> p * (1 - p)) . proportions
+
+
+-- misclassification coefficient as an impurity measure
+
+misclassification ::
+     (Mutable r Ix1 a, Resize r ix, Ord a, Load r ix a)
+  => Array r ix a
+  -> Double
+misclassification xs = 1 - maximum' (proportions xs)

--- a/src/ImpurityMassiv.hs
+++ b/src/ImpurityMassiv.hs
@@ -35,6 +35,7 @@ proportions arr = A.map (\c -> fromIntegral c / n) counts
   where
     counts = computeAs P (snd <$> tally arr)
     n = fromIntegral $ unSz $ size counts
+{-# INLINE proportions #-}
 
 
 entropy ::
@@ -42,6 +43,7 @@ entropy ::
   => Array r ix a
   -> Double
 entropy = negate . A.sum . A.map (\p -> p * logBase 2 p) . proportions
+{-# INLINE entropy #-}
 
 
 
@@ -50,6 +52,7 @@ gini ::
   => Array r ix a
   -> Double
 gini = A.sum . A.map (\p -> p * (1 - p)) . proportions
+{-# INLINE gini #-}
 
 
 -- misclassification coefficient as an impurity measure
@@ -59,3 +62,4 @@ misclassification ::
   => Array r ix a
   -> Double
 misclassification xs = 1 - maximum' (proportions xs)
+{-# INLINE misclassification #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.3
+resolver: lts-14.12
 packages:
 - .
 

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 523878
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/3.yaml
-    sha256: 470c46c27746a48c7c50f829efc0cf00112787a7804ee4ac7a27754658f6d92c
-  original: lts-14.3
+    size: 545658
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/14/12.yaml
+    sha256: 26b807457213126d26b595439d705dc824dbb7618b0de6b900adc2bf6a059406
+  original: lts-14.12


### PR DESCRIPTION
The number next to `Impurity` 20/2000/200000 is the maximum value in randomly generated values. Which means higher the number less duplicates the array will contain, thus larged the resulting array of tally will be. The reason why this number doesn't affect massiv as much as it does the `Map`+`List` solution is because less duplicate there is the sorting algorithms starts to run a bit faster, also parallelization works better. For many duplicates parallel version runs just as fast as the sequential one.
```
Benchmark impurity: RUNNING...
benchmarking Impurity 20/Massiv/Tally
time                 9.873 ms   (9.468 ms .. 10.37 ms)
                     0.983 R²   (0.965 R² .. 0.994 R²)
mean                 10.25 ms   (9.888 ms .. 11.39 ms)
std dev              1.541 ms   (832.8 μs .. 2.976 ms)
variance introduced by outliers: 72% (severely inflated)

benchmarking Impurity 20/List+Map/Tally
time                 31.90 ms   (30.78 ms .. 32.98 ms)
                     0.996 R²   (0.992 R² .. 0.999 R²)
mean                 31.33 ms   (30.58 ms .. 32.25 ms)
std dev              1.952 ms   (1.269 ms .. 3.118 ms)
variance introduced by outliers: 22% (moderately inflated)

benchmarking Impurity 2000/Massiv/Tally
time                 10.25 ms   (9.678 ms .. 10.93 ms)
                     0.976 R²   (0.948 R² .. 0.995 R²)
mean                 10.92 ms   (10.47 ms .. 12.14 ms)
std dev              1.964 ms   (741.5 μs .. 3.525 ms)
variance introduced by outliers: 78% (severely inflated)

benchmarking Impurity 2000/List+Map/Tally
time                 85.86 ms   (82.48 ms .. 88.71 ms)
                     0.996 R²   (0.989 R² .. 0.999 R²)
mean                 86.36 ms   (80.18 ms .. 89.45 ms)
std dev              7.159 ms   (2.631 ms .. 11.10 ms)
variance introduced by outliers: 28% (moderately inflated)

benchmarking Impurity 200000/Massiv/Tally
time                 12.13 ms   (11.47 ms .. 12.72 ms)
                     0.980 R²   (0.949 R² .. 0.996 R²)
mean                 12.53 ms   (12.21 ms .. 13.44 ms)
std dev              1.419 ms   (603.7 μs .. 2.503 ms)
variance introduced by outliers: 58% (severely inflated)

benchmarking Impurity 200000/List+Map/Tally
time                 324.3 ms   (305.0 ms .. 348.8 ms)
                     0.998 R²   (0.990 R² .. 1.000 R²)
mean                 328.3 ms   (320.5 ms .. 336.3 ms)
std dev              9.396 ms   (5.721 ms .. 14.44 ms)
variance introduced by outliers: 16% (moderately inflated)

```